### PR TITLE
chore - update dependency for m1 chip

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("com.android.application")
     id("kotlin-android")
     id("kotlin-parcelize")
-    id("kotlin-kapt")
+    kotlin("kapt")
     id("androidx.navigation.safeargs.kotlin")
     id("com.google.firebase.crashlytics")
     id("dagger.hilt.android.plugin")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
         android:theme="@style/AppTheme"
         tools:targetApi="m">
         <activity android:name="com.mayokunadeniyi.instantweather.ui.MainActivity"
-            android:theme="@style/SplashScreenTheme">
+            android:theme="@style/SplashScreenTheme"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.kotlin.dsl.`kotlin-dsl`
+
 plugins {
     `kotlin-dsl`
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -6,8 +6,8 @@ import org.gradle.api.JavaVersion
 
 object Config {
     const val minSdkVersion = 21
-    const val compileSdkVersion = 30
-    const val targetSdkVersion = 30
+    const val compileSdkVersion = 31
+    const val targetSdkVersion = 31
     const val versionName = "1.0"
     const val versionCode = 5
     val javaVersion = JavaVersion.VERSION_11
@@ -43,7 +43,7 @@ object Plugins {
 object Kotlin {
 
     object Versions {
-        const val kotlin = "1.4.21"
+        const val kotlin = "1.6.0"
         const val coroutines = "1.4.2"
     }
 
@@ -66,10 +66,10 @@ object AndroidX : Libraries {
         const val legacy = "1.0.0"
         const val work = "2.5.0"
         const val paging = "2.1.2"
-        const val fragment = "1.3.0-alpha06"
+        const val fragment = "1.4.0"
 
         const val archCoreTesting = "2.1.0"
-        const val coreKtxTest = "1.3.0"
+        const val coreKtxTest = "1.4.0"
         const val testExt = "1.1.2"
         const val testRules = "1.3.0"
     }
@@ -138,7 +138,7 @@ object Network : Libraries {
 object Database : Libraries {
 
     object Versions {
-        const val room = "2.2.6"
+        const val room = "2.4.2"
     }
 
     const val roomRuntime = "androidx.room:room-runtime:${Versions.room}"


### PR DESCRIPTION
demand
1. m1 chip require room version higher than 2.4.0-alpha03

modify

1. buildSrc/build.gradle.kts
  - import org.gradle.kotlin.dsl.`kotlin-dsl`
2. buildSrc/src/main/kotlin/Dependencies.kt
  - upgrade targetsdk, compile sdk due to room require them greater or equal 31
  - upgrade kotlin, fragment, coreEtxTest, room version due to sdk version change
3.  app/src/main/AndroidManifest.xml
  - add `export=true|false` for activity, it is necessary for sdk greater than 30

Ref: #50 